### PR TITLE
Refactor unit tests: Use stubFetchUrlMap to redirect fetch calls

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,17 +1,15 @@
 import { append } from '../../scripts/utils/dom.js';
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { addArchiveLinks, getSiteRoot } from '../../scripts/utils/site.js';
 import { decorateExternalLinks } from '../../scripts/scripts.js';
 
 /**
  * @param {Element} footerNav
- * @param {object} cfg
  */
-function decorateFooterNav(footerNav, cfg) {
+function decorateFooterNav(footerNav) {
   footerNav.classList.add('section-footernav');
 
   // add archive links to last footernav item
-  addArchiveLinks(footerNav, cfg.queryindexurl || '/query-index.json');
+  addArchiveLinks(footerNav);
 }
 
 /**
@@ -49,13 +47,11 @@ function decorateFooterText(footerText) {
  * @param {Element} block The footer block element
  */
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
   block.textContent = '';
 
   // fetch nav content
   const siteRoot = getSiteRoot(document.location.pathname);
-  const navPath = cfg.footer || `${siteRoot}footer`;
-  const resp = await fetch(`${navPath}.plain.html`);
+  const resp = await fetch(`${siteRoot}footer.plain.html`);
   if (resp.ok) {
     const html = await resp.text();
     const container = append(block, 'div');
@@ -65,7 +61,7 @@ export default async function decorate(block) {
     // first section: footer navigation
     const footerNav = container.children[0];
     if (footerNav) {
-      decorateFooterNav(footerNav, cfg);
+      decorateFooterNav(footerNav);
     }
 
     // second section: footer text

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,5 +1,4 @@
 import { append, prepend } from '../../scripts/utils/dom.js';
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { addArchiveLinks, getSiteRoot } from '../../scripts/utils/site.js';
 import { decorateExternalLinks } from '../../scripts/scripts.js';
 
@@ -19,9 +18,8 @@ function decorateHeader(header, siteRoot) {
 
 /**
  * @param {Element} mainNav
- * @param {object} cfg
  */
-function decorateMainNav(mainNav, cfg) {
+function decorateMainNav(mainNav) {
   mainNav.classList.add('section-mainnav');
 
   // mobile navigation
@@ -52,7 +50,7 @@ function decorateMainNav(mainNav, cfg) {
   });
 
   // add archive links to last mainnav item
-  addArchiveLinks(mainNav, cfg.queryindexurl || '/query-index.json');
+  addArchiveLinks(mainNav);
 }
 
 /**
@@ -60,13 +58,11 @@ function decorateMainNav(mainNav, cfg) {
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
   block.textContent = '';
 
   // fetch nav content
   const siteRoot = getSiteRoot(document.location.pathname);
-  const navPath = cfg.nav || `${siteRoot}nav`;
-  const resp = await fetch(`${navPath}.plain.html`);
+  const resp = await fetch(`${siteRoot}nav.plain.html`);
   if (resp.ok) {
     const html = await resp.text();
     const nav = document.createElement('nav');
@@ -82,7 +78,7 @@ export default async function decorate(block) {
     // second section: main navigation
     const mainNav = nav.children[1];
     if (mainNav) {
-      decorateMainNav(mainNav, cfg);
+      decorateMainNav(mainNav);
     }
 
     block.append(nav);

--- a/blocks/schedule/schedule.js
+++ b/blocks/schedule/schedule.js
@@ -1,5 +1,4 @@
 import { append } from '../../scripts/utils/dom.js';
-import { readBlockConfig } from '../../scripts/lib-franklin.js';
 import { getScheduleData } from '../../scripts/services/ScheduleData.js';
 import { getSiteRoot } from '../../scripts/utils/site.js';
 import { formatDateFull, formatTime } from '../../scripts/utils/datetime.js';
@@ -166,14 +165,11 @@ function buildDaySchedule(parent, day, activeDay) {
  * @param {Element} block
  */
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
   block.textContent = '';
 
   // load schedule data
   const siteRoot = getSiteRoot(document.location.pathname);
-  const scheduleDataUrl = cfg.scheduledataurl || `${siteRoot}schedule-data.json`;
-  const queryIndexUrl = cfg.queryindexurl || '/query-index.json';
-  const scheduleData = await getScheduleData(scheduleDataUrl, queryIndexUrl);
+  const scheduleData = await getScheduleData(`${siteRoot}schedule-data.json`);
 
   // detect active day
   let activeDay = getActiveDayFromHash();

--- a/blocks/talk-detail-after-outline/talk-detail-after-outline.js
+++ b/blocks/talk-detail-after-outline/talk-detail-after-outline.js
@@ -1,5 +1,5 @@
 import { append } from '../../scripts/utils/dom.js';
-import { createOptimizedPicture, getMetadata, readBlockConfig } from '../../scripts/lib-franklin.js';
+import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
 import { getQueryIndex } from '../../scripts/services/QueryIndex.js';
 import { parseCSVArray } from '../../scripts/utils/metadata.js';
 import { getSpeakerOverviewPage } from '../../scripts/utils/site.js';
@@ -86,8 +86,7 @@ function buildLinks(parent) {
  * @param {Element} block
  */
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
-  const queryIndex = await getQueryIndex(cfg.queryindexurl || '/query-index.json');
+  const queryIndex = await getQueryIndex();
 
   buildSpeakers(block, queryIndex);
   buildLinks(block);

--- a/blocks/talk-detail-before-outline/talk-detail-before-outline.js
+++ b/blocks/talk-detail-before-outline/talk-detail-before-outline.js
@@ -1,9 +1,4 @@
-import {
-  decorateBlock,
-  getMetadata,
-  loadBlocks,
-  readBlockConfig,
-} from '../../scripts/lib-franklin.js';
+import { decorateBlock, getMetadata, loadBlocks } from '../../scripts/lib-franklin.js';
 import { getScheduleData } from '../../scripts/services/ScheduleData.js';
 import { formatDateFull, formatTime } from '../../scripts/utils/datetime.js';
 import { append } from '../../scripts/utils/dom.js';
@@ -69,15 +64,12 @@ function buildVideo(parent) {
  * @param {Element} block
  */
 export default async function decorate(block) {
-  const cfg = readBlockConfig(block);
   block.textContent = '';
 
   // get schedule entry for talk
   const siteRoot = getSiteRoot(document.location.pathname);
-  const scheduleDataUrl = cfg.scheduledataurl || `${siteRoot}schedule-data.json`;
-  const queryIndexUrl = cfg.queryindexurl || '/query-index.json';
-  const scheduleData = await getScheduleData(scheduleDataUrl, queryIndexUrl);
-  const scheduleEntry = scheduleData.getTalkEntry(cfg.talkpath || document.location.pathname);
+  const scheduleData = await getScheduleData(`${siteRoot}schedule-data.json`);
+  const scheduleEntry = scheduleData.getTalkEntry(document.location.pathname);
 
   buildTalkTags(block, siteRoot);
   if (scheduleEntry) {

--- a/scripts/services/QueryIndex.js
+++ b/scripts/services/QueryIndex.js
@@ -3,7 +3,7 @@ import QueryIndexItem from './QueryIndexItem.js';
 
 const siteRootRegex = /^\/\d\d\d\d\/$/;
 const speakerPathRegex = /^\/speakers\/.*$/;
-const queryIndexCache = new Set();
+let queryIndexInstance;
 
 /**
  * Helper for getting information about published pages and metadata.
@@ -58,13 +58,12 @@ export default class QueryIndex {
 }
 
 /**
- * @param {string} url Url to query-index.json
+ * Get Query Index based on query-index.json.
  */
-export async function getQueryIndex(url) {
-  let queryIndexInstance = queryIndexCache[url];
+export async function getQueryIndex() {
   if (!queryIndexInstance) {
     let data;
-    const resp = await fetch(url);
+    const resp = await fetch('/query-index.json');
     if (resp.ok) {
       const json = await resp.json();
       data = json.data;
@@ -72,7 +71,13 @@ export async function getQueryIndex(url) {
     data = data || [];
     const items = data.map((item) => Object.assign(new QueryIndexItem(), item));
     queryIndexInstance = new QueryIndex(items);
-    queryIndexCache[url] = queryIndexInstance;
   }
   return queryIndexInstance;
+}
+
+/**
+ * Clears internal cache of query index responses.
+ */
+export function clearQueryIndexCache() {
+  queryIndexInstance = undefined;
 }

--- a/scripts/services/ScheduleData.js
+++ b/scripts/services/ScheduleData.js
@@ -148,16 +148,15 @@ function toDays(scheduleData, queryIndex) {
 
 /**
  * @param {string} scheduleDataUrl Url to schedule-data.json
- * @param {string} queryIndexUrl Url to query-index.json
  */
-export async function getScheduleData(scheduleDataUrl, queryIndexUrl) {
+export async function getScheduleData(scheduleDataUrl) {
   let scheduleData;
   const resp = await fetch(scheduleDataUrl);
   if (resp.ok) {
     const json = await resp.json();
     scheduleData = json.data;
   }
-  const queryIndex = await getQueryIndex(queryIndexUrl);
+  const queryIndex = await getQueryIndex();
   const days = toDays(scheduleData || [], queryIndex);
   return new ScheduleData(days);
 }

--- a/scripts/utils/site.js
+++ b/scripts/utils/site.js
@@ -64,13 +64,13 @@ export function getSpeakerOverviewPage(pathname) {
  * @param {Element} nav Navigation element
  * @param {string} queryIndexUrl URL pointing to query-index json
  */
-export async function addArchiveLinks(nav, queryIndexUrl) {
+export async function addArchiveLinks(nav) {
   const navItems = nav.querySelectorAll(':scope > ul > li');
   const lastNavItem = navItems[navItems.length - 1];
   if (lastNavItem) {
     const ul = lastNavItem.querySelector(':scope > ul');
     if (ul) {
-      const queryIndex = await getQueryIndex(queryIndexUrl);
+      const queryIndex = await getQueryIndex();
       queryIndex.getAllSiteRoots().forEach((siteRoot) => {
         const listItem = append(ul, 'li');
         const link = append(listItem, 'a');

--- a/test/blocks/header/header.test.js
+++ b/test/blocks/header/header.test.js
@@ -3,22 +3,18 @@
 
 import { readFile } from '@web/test-runner-commands';
 import { expect } from '@esm-bundle/chai';
+import { setWindowLocationHref, sleep, stubFetchUrlMap } from '../../scripts/test-utils.js';
 
-const { buildBlock, decorateBlock, loadBlock } = await import('../../../scripts/lib-franklin.js');
+// simulate current talk and redirect some fetch calls to mock data
+setWindowLocationHref('/2021/');
+stubFetchUrlMap({
+  '/2021/nav.plain.html': '/test/blocks/header/nav.plain.html',
+  '/query-index.json': '/test/test-data/query-index-sample.json',
+});
 
 document.body.innerHTML = await readFile({ path: '../../scripts/body.html' });
 
-const sleep = async (time = 1000) => new Promise((resolve) => {
-  setTimeout(() => {
-    resolve(true);
-  }, time);
-});
-
-const headerBlock = buildBlock('header', [['nav', '/test/blocks/header/nav'],
-  ['queryindexurl', '/test/test-data/query-index-sample.json']]);
-document.querySelector('header').append(headerBlock);
-decorateBlock(headerBlock);
-await loadBlock(headerBlock);
+await import('../../../scripts/scripts.js');
 await sleep();
 
 describe('blocks/header', () => {
@@ -28,7 +24,7 @@ describe('blocks/header', () => {
 
     const logo = header.querySelector('a.logo');
     expect(logo).to.exist;
-    expect(logo.href).to.eq('http://localhost:2000/');
+    expect(logo.href).to.eq('http://localhost:2000/2021/');
 
     const h1 = header.querySelector('h1');
     expect(h1).to.exist;

--- a/test/blocks/schedule/schedule.test.js
+++ b/test/blocks/schedule/schedule.test.js
@@ -4,16 +4,23 @@
 import { expect } from '@esm-bundle/chai';
 import { buildBlock } from '../../../scripts/lib-franklin.js';
 import decorate from '../../../blocks/schedule/schedule.js';
+import { setWindowLocationHref, stubFetchUrlMap } from '../../scripts/test-utils.js';
+import { clearQueryIndexCache } from '../../../scripts/services/QueryIndex.js';
 
 /**
  * @param {string} year
  */
 async function buildScheduleBlock(year) {
-  const block = buildBlock('schedule', [
-    ['scheduledataurl', `/test/test-data/schedule-data-${year}.json`],
-    ['queryindexurl', `/test/test-data/query-index-schedule-${year}.json`],
-  ]);
+  clearQueryIndexCache();
+  // simulate schedule URL and redirect fetch calls to mock data
+  setWindowLocationHref(`/${year}/schedule`);
+  const stub = stubFetchUrlMap({
+    [`/${year}/schedule-data.json`]: `/test/test-data/schedule-data-${year}.json`,
+    '/query-index.json': `/test/test-data/query-index-schedule-${year}.json`,
+  });
+  const block = buildBlock('schedule', []);
   await decorate(block);
+  stub.restore();
   return block;
 }
 

--- a/test/scripts/services/QueryIndex.test.js
+++ b/test/scripts/services/QueryIndex.test.js
@@ -3,8 +3,10 @@
 
 import { expect } from '@esm-bundle/chai';
 import { getQueryIndex } from '../../../scripts/services/QueryIndex.js';
+import { stubFetchUrlMap } from '../test-utils.js';
 
-const queryIndex = await getQueryIndex('/test/test-data/query-index-sample.json');
+stubFetchUrlMap({ '/query-index.json': '/test/test-data/query-index-sample.json' });
+const queryIndex = await getQueryIndex();
 
 describe('services/QueryIndex', () => {
   it('getItem-all-properties', () => {

--- a/test/scripts/services/ScheduleData.test.js
+++ b/test/scripts/services/ScheduleData.test.js
@@ -3,11 +3,10 @@
 
 import { expect } from '@esm-bundle/chai';
 import { getScheduleData } from '../../../scripts/services/ScheduleData.js';
+import { stubFetchUrlMap } from '../test-utils.js';
 
-const scheduleData = await getScheduleData(
-  '/test/test-data/schedule-data-2020.json',
-  '/test/test-data/query-index-schedule-2020.json',
-);
+stubFetchUrlMap({ '/query-index.json': '/test/test-data/query-index-schedule-2020.json' });
+const scheduleData = await getScheduleData('/test/test-data/schedule-data-2020.json');
 
 describe('services/ScheduleData', () => {
   it('getDays', () => {

--- a/test/scripts/test-utils.js
+++ b/test/scripts/test-utils.js
@@ -33,6 +33,18 @@ export async function blockLoaded(section) {
 }
 
 /**
+ * Pause execution for given amount of time.
+ * @param {number} time Time (ms)
+ */
+export async function sleep(time = 1000) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(true);
+    }, time);
+  });
+}
+
+/**
  * Stubs window.fetch method to redirect URLs matching keys
  * in the given map to other URLs given as map values.
  * @param {object} urlMap Maps requested URLs to other URLs.


### PR DESCRIPTION
eliminate block config code only related to unit tests

Test URLs:
- Before: https://main--adaptto-website--adaptto.hlx.page/
- After: https://feature-refactore-unit-test-fetch--adaptto-website--adaptto.hlx.page/
