### PR TITLE
Use "back to parent" for 2nd level talk pages

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,5 +1,5 @@
 import { append } from '../../scripts/utils/dom.js';
-import { addArchiveLinks, getSiteRoot } from '../../scripts/utils/site.js';
+import { addArchiveLinks, getSiteRootPath } from '../../scripts/utils/site.js';
 import { decorateExternalLinks } from '../../scripts/scripts.js';
 
 /**
@@ -50,7 +50,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // fetch nav content
-  const siteRoot = getSiteRoot(document.location.pathname);
+  const siteRoot = getSiteRootPath(document.location.pathname);
   const resp = await fetch(`${siteRoot}footer.plain.html`);
   if (resp.ok) {
     const html = await resp.text();

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,5 +1,5 @@
 import { append, prepend } from '../../scripts/utils/dom.js';
-import { addArchiveLinks, getSiteRoot } from '../../scripts/utils/site.js';
+import { addArchiveLinks, getSiteRootPath } from '../../scripts/utils/site.js';
 import { decorateExternalLinks } from '../../scripts/scripts.js';
 
 /**
@@ -61,7 +61,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // fetch nav content
-  const siteRoot = getSiteRoot(document.location.pathname);
+  const siteRoot = getSiteRootPath(document.location.pathname);
   const resp = await fetch(`${siteRoot}nav.plain.html`);
   if (resp.ok) {
     const html = await resp.text();

--- a/blocks/schedule/schedule.js
+++ b/blocks/schedule/schedule.js
@@ -1,6 +1,6 @@
 import { append } from '../../scripts/utils/dom.js';
 import { getScheduleData } from '../../scripts/services/ScheduleData.js';
-import { getSiteRoot } from '../../scripts/utils/site.js';
+import { getSiteRootPath } from '../../scripts/utils/site.js';
 import { formatDateFull, formatTime } from '../../scripts/utils/datetime.js';
 
 const dayIdPattern = /^#day-(\d)$/;
@@ -168,7 +168,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // load schedule data
-  const siteRoot = getSiteRoot(document.location.pathname);
+  const siteRoot = getSiteRootPath(document.location.pathname);
   const scheduleData = await getScheduleData(`${siteRoot}schedule-data.json`);
 
   // detect active day

--- a/blocks/talk-detail-after-outline/talk-detail-after-outline.js
+++ b/blocks/talk-detail-after-outline/talk-detail-after-outline.js
@@ -2,7 +2,7 @@ import { append } from '../../scripts/utils/dom.js';
 import { createOptimizedPicture, getMetadata } from '../../scripts/lib-franklin.js';
 import { getQueryIndex } from '../../scripts/services/QueryIndex.js';
 import { parseCSVArray } from '../../scripts/utils/metadata.js';
-import { getSpeakerOverviewPage } from '../../scripts/utils/site.js';
+import { getSpeakerOverviewPath } from '../../scripts/utils/site.js';
 import { getDocumentName } from '../../scripts/utils/path.js';
 
 /**
@@ -23,7 +23,7 @@ function buildSpeakers(parent, queryIndex) {
   const ul = append(parent, 'ul', 'speakers');
   speakers.forEach((speakerItem) => {
     const li = append(ul, 'li');
-    const speakerUrl = `${getSpeakerOverviewPage(window.location.pathname)}#${getDocumentName(speakerItem.path)}`;
+    const speakerUrl = `${getSpeakerOverviewPath(window.location.pathname)}#${getDocumentName(speakerItem.path)}`;
 
     if (speakerItem.image) {
       const imageAnchor = append(li, 'a');

--- a/blocks/talk-detail-before-outline/talk-detail-before-outline.js
+++ b/blocks/talk-detail-before-outline/talk-detail-before-outline.js
@@ -3,7 +3,7 @@ import { getScheduleData } from '../../scripts/services/ScheduleData.js';
 import { formatDateFull, formatTime } from '../../scripts/utils/datetime.js';
 import { append } from '../../scripts/utils/dom.js';
 import { parseCSVArray } from '../../scripts/utils/metadata.js';
-import { getArchivePage, getSiteRoot } from '../../scripts/utils/site.js';
+import { getArchivePath, getSiteRootPath } from '../../scripts/utils/site.js';
 
 /**
  * Build talk tags (with link to talk archive).
@@ -20,7 +20,7 @@ function buildTalkTags(parent, siteRoot) {
   tags.forEach((tag) => {
     const li = append(ul, 'li');
     const a = append(li, 'a');
-    a.href = `${getArchivePage(document.location.pathname)}#${siteRoot.substring(1)}${tag}`;
+    a.href = `${getArchivePath(document.location.pathname)}#${siteRoot.substring(1)}${tag}`;
     a.textContent = tag;
   });
 }
@@ -67,7 +67,7 @@ export default async function decorate(block) {
   block.textContent = '';
 
   // get schedule entry for talk
-  const siteRoot = getSiteRoot(document.location.pathname);
+  const siteRoot = getSiteRootPath(document.location.pathname);
   const scheduleData = await getScheduleData(`${siteRoot}schedule-data.json`);
   const scheduleEntry = scheduleData.getTalkEntry(document.location.pathname);
 

--- a/blocks/talk-detail-footer/talk-detail-footer.js
+++ b/blocks/talk-detail-footer/talk-detail-footer.js
@@ -1,5 +1,5 @@
 import { append } from '../../scripts/utils/dom.js';
-import { getSchedulePage } from '../../scripts/utils/site.js';
+import { getParentPath, getSchedulePath } from '../../scripts/utils/site.js';
 
 /**
  * Talk Detail footer with back to schedule link.
@@ -8,7 +8,15 @@ import { getSchedulePage } from '../../scripts/utils/site.js';
 export default async function decorate(block) {
   const p = append(block, 'p');
 
+  const parentPath = getParentPath(document.location.pathname);
+  const schedulePath = getSchedulePath(document.location.pathname);
+
   const backLink = append(p, 'a');
-  backLink.href = getSchedulePage(document.location.pathname);
-  backLink.textContent = 'Back to schedule';
+  backLink.href = parentPath;
+  if (parentPath == schedulePath) {
+    backLink.textContent = 'Back to schedule';
+  }
+  else {
+    backLink.textContent = 'Back to parent';
+  }
 }

--- a/blocks/talk-detail-footer/talk-detail-footer.js
+++ b/blocks/talk-detail-footer/talk-detail-footer.js
@@ -13,10 +13,9 @@ export default async function decorate(block) {
 
   const backLink = append(p, 'a');
   backLink.href = parentPath;
-  if (parentPath == schedulePath) {
+  if (parentPath === schedulePath) {
     backLink.textContent = 'Back to schedule';
-  }
-  else {
+  } else {
     backLink.textContent = 'Back to parent';
   }
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -13,7 +13,7 @@ import {
   getMetadata,
 } from './lib-franklin.js';
 import { getHostName } from './utils/path.js';
-import { getSiteRoot } from './utils/site.js';
+import { getSiteRootPath } from './utils/site.js';
 
 const LCP_BLOCKS = []; // add your LCP blocks to the list
 window.hlx.RUM_GENERATION = 'project-1'; // add your RUM generation information here
@@ -86,7 +86,7 @@ function decorateTalkDetailPage(main) {
  * @returns Fragment block element
  */
 function buildFragmentBlock(fragmentRef) {
-  const siteRootPath = getSiteRoot(window.location.pathname);
+  const siteRootPath = getSiteRootPath(window.location.pathname);
   const fragmentPath = `${siteRootPath}${fragmentRef}`;
   const fragmentLink = document.createElement('a');
   fragmentLink.setAttribute('href', fragmentPath);

--- a/scripts/utils/site.js
+++ b/scripts/utils/site.js
@@ -9,11 +9,11 @@ const siteRootRegex = /^(\/[^/]+\/)(.+)?$/;
  *   / -> /
  *   /2021/ -> /2021/
  *   /2021/mypage -> /2021/
- * @param {string} pathname Path name
+ * @param {string} pathName Path name
  * @returns Site root path
  */
-export function getSiteRoot(pathname) {
-  const result = pathname.match(siteRootRegex);
+export function getSiteRootPath(pathName) {
+  const result = pathName.match(siteRootRegex);
   if (result) {
     return result[1];
   }
@@ -21,41 +21,58 @@ export function getSiteRoot(pathname) {
 }
 
 /**
+ * Gets parent path. Topmost parent path is the site root.
+ * @param {string} pathName Path name
+ * @returns {string} Parent path or undefined if the path is already site root or invalid.
+ */
+export function getParentPath(pathName) {
+  const siteRoot = getSiteRootPath(pathName);
+  if (pathName !== siteRoot && siteRoot !== '/') {
+    const lastSlash = pathName.lastIndexOf('/');
+    if (lastSlash === siteRoot.length - 1) {
+      return siteRoot;
+    }
+    return pathName.substring(0, lastSlash);
+  }
+  return undefined;
+}
+
+/**
  * Build page path in current site.
- * @param {string} pathname location.pathname
+ * @param {string} pathName location.pathName
  * @param {string} path relative path inside site (without leading slash)
  * @returns {string} Path
  */
-function getRelativePage(pathname, path) {
-  const siteRoot = getSiteRoot(pathname);
+function getRelativePage(pathName, path) {
+  const siteRoot = getSiteRootPath(pathName);
   return `${siteRoot}${path}`;
 }
 
 /**
  * Build path to schedule page in current site.
- * @param {string} pathname location.pathname
+ * @param {string} pathName location.pathName
  * @returns {string} Path
  */
-export function getSchedulePage(pathname) {
-  return getRelativePage(pathname, 'schedule');
+export function getSchedulePath(pathName) {
+  return getRelativePage(pathName, 'schedule');
 }
 
 /**
  * Build path to archive page in current site.
- * @param {string} pathname location.pathname
+ * @param {string} pathName location.pathName
  * @returns {string} Path
  */
-export function getArchivePage(pathname) {
-  return getRelativePage(pathname, 'archive');
+export function getArchivePath(pathName) {
+  return getRelativePage(pathName, 'archive');
 }
 
 /**
  * Build path to speaker overview page in current site.
- * @param {string} pathname location.pathname
+ * @param {string} pathName location.pathName
  * @returns {string} Path
  */
-export function getSpeakerOverviewPage(pathname) {
-  return getRelativePage(pathname, 'conference/speaker');
+export function getSpeakerOverviewPath(pathName) {
+  return getRelativePage(pathName, 'conference/speaker');
 }
 
 /**

--- a/test/scripts/utils/site.test.js
+++ b/test/scripts/utils/site.test.js
@@ -3,29 +3,38 @@
 
 import { expect } from '@esm-bundle/chai';
 import {
-  getArchivePage,
-  getSchedulePage,
-  getSiteRoot,
-  getSpeakerOverviewPage,
+  getArchivePath,
+  getParentPath,
+  getSchedulePath,
+  getSiteRootPath,
+  getSpeakerOverviewPath,
 } from '../../../scripts/utils/site.js';
 
 describe('utils/site', () => {
-  it('getSiteRoot', () => {
-    expect(getSiteRoot('/')).to.equal('/');
-    expect(getSiteRoot('/2021/')).to.equal('/2021/');
-    expect(getSiteRoot('/2021/mypage')).to.equal('/2021/');
-    expect(getSiteRoot('/2021/mypage/mysubpage/')).to.equal('/2021/');
+  it('getSiteRootPath', () => {
+    expect(getSiteRootPath('/')).to.equal('/');
+    expect(getSiteRootPath('/2021/')).to.equal('/2021/');
+    expect(getSiteRootPath('/2021/mypage')).to.equal('/2021/');
+    expect(getSiteRootPath('/2021/mypage/mysubpage')).to.equal('/2021/');
   });
 
-  it('getSchedulePage', () => {
-    expect(getSchedulePage('/2021/mypage')).to.equal('/2021/schedule');
+  it('getParentPath', () => {
+    expect(getParentPath('/')).to.undefined;
+    expect(getParentPath('/2021/')).to.undefined;
+    expect(getParentPath('/2021/mypage')).to.equal('/2021/');
+    expect(getParentPath('/2021/mypage/mysubpage')).to.equal('/2021/mypage');
+    expect(getParentPath('/2021/mypage/mysubpage/sub2')).to.equal('/2021/mypage/mysubpage');
   });
 
-  it('getArchivePage', () => {
-    expect(getArchivePage('/2021/mypage')).to.equal('/2021/archive');
+  it('getSchedulePath', () => {
+    expect(getSchedulePath('/2021/mypage')).to.equal('/2021/schedule');
   });
 
-  it('getSpeakerOverviewPage', () => {
-    expect(getSpeakerOverviewPage('/2021/mypage')).to.equal('/2021/conference/speaker');
+  it('getArchivePath', () => {
+    expect(getArchivePath('/2021/mypage')).to.equal('/2021/archive');
+  });
+
+  it('getSpeakerOverviewPath', () => {
+    expect(getSpeakerOverviewPath('/2021/mypage')).to.equal('/2021/conference/speaker');
   });
 });


### PR DESCRIPTION
also refactor path-related method names in site utils

Test URLs:
- Before: https://main--adaptto-website--adaptto.hlx.page/
- After: https://feature-schedule-back-to-parent--adaptto-website--adaptto.hlx.page/
