### PR TITLE
Image Gallery Overlay: use marker class instead of :has selector

### DIFF
--- a/blocks/image-gallery/image-gallery.css
+++ b/blocks/image-gallery/image-gallery.css
@@ -184,6 +184,6 @@
   position: relative;
 }
 
-body:has(#image-gallery-overlay) {
+body.image-gallery-overlay {
   overflow: hidden;
 }

--- a/blocks/image-gallery/image-gallery.js
+++ b/blocks/image-gallery/image-gallery.js
@@ -134,8 +134,10 @@ function displayCurrentStateImage(block, imageUrls) {
   if (state.fullscreen) {
     const overlay = createOverlay();
     displayImage(overlay, imageUrls, state.index, true);
+    document.body.classList.add('image-gallery-overlay');
   } else {
     removeOverlay();
+    document.body.classList.remove('image-gallery-overlay');
   }
 }
 


### PR DESCRIPTION
:has not supported in Firefox

Test URLs:
- Before: https://main--adaptto-website--adaptto.hlx.live/2021/conference/gallery#fullscreen-image-1
- After: https://feature-gallery-overlay-firefox-fix--adaptto-website--adaptto.hlx.live/2021/conference/gallery#fullscreen-image-1
