### PR TITLE
Show Outline headline only if outline content exists

### DIFF
--- a/blocks/talk-detail-before-outline/talk-detail-before-outline.js
+++ b/blocks/talk-detail-before-outline/talk-detail-before-outline.js
@@ -59,6 +59,13 @@ function buildVideo(parent) {
 }
 
 /**
+ * @returns true if any "p" or "li" element is found in the default content.
+ */
+function isOutlinePresent() {
+  return document.querySelectorAll('main .default-content-wrapper p, main .default-content-wrapper li').length > 0
+}
+
+/**
  * Talk detail before outline: Tags, time info and video.
  * @param {Element} block
  */
@@ -75,5 +82,7 @@ export default async function decorate(block) {
     buildTimeInfo(block, scheduleEntry);
   }
   buildVideo(block);
-  append(block, 'h4').textContent = 'Outline';
+  if (isOutlinePresent()) {
+    append(block, 'h4').textContent = 'Outline';
+  }
 }

--- a/blocks/talk-detail-before-outline/talk-detail-before-outline.js
+++ b/blocks/talk-detail-before-outline/talk-detail-before-outline.js
@@ -62,7 +62,7 @@ function buildVideo(parent) {
  * @returns true if any "p" or "li" element is found in the default content.
  */
 function isOutlinePresent() {
-  return document.querySelectorAll('main .default-content-wrapper p, main .default-content-wrapper li').length > 0
+  return document.querySelectorAll('main .default-content-wrapper p, main .default-content-wrapper li').length > 0;
 }
 
 /**


### PR DESCRIPTION
Test URLs:
- Before: https://main--adaptto-website--adaptto.hlx.live/2021/schedule/lightning-talks/40-years-of-the-bbc-micro
- After: https://feature-skip-empty-outline--adaptto-website--adaptto.hlx.live/2021/schedule/lightning-talks/40-years-of-the-bbc-micro
