### PR TITLE
Scale content images always to 100%

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -123,7 +123,7 @@ h6 {
 
 img {
   margin: 0 auto;
-  max-width: 100%;
+  width: 100%;
   height: auto;
 }
 


### PR DESCRIPTION
it seems that images uploaded in sharepoint word documents get strange default with/height attributes (e.g. width=256) although the source images is >2000px width. so we need to scale always as desired and cannot rely on the max. dimension of the source image.

Test URLs:
- Before: https://main--adaptto-website--adaptto.hlx.live/2023/sign-up/call-for-papers
- After: https://feature-content-image--adaptto-website--adaptto.hlx.live/2023/sign-up/call-for-papers
