### PR TITLE
Make compatible with Helix 5 aem.page/live URLs

### DIFF
--- a/scripts/services/Link.js
+++ b/scripts/services/Link.js
@@ -1,4 +1,4 @@
-const adaptToSiteUrlRegex = /^https?:\/\/([^/.]+--adaptto-website--adaptto.hlx.(page|live)|adapt.to|franklin.adaptto.de|localhost:\d+)(\/.+)$/;
+const adaptToSiteUrlRegex = /^https?:\/\/([^/.]+--adaptto-website--adaptto.(hlx|aem).(page|live)|adapt.to|localhost:\d+)(\/.+)$/;
 const adaptToSiteUrlPathnameGroup = 3;
 const downloadUrlRegex = /^.+\.(pdf|zip)$/;
 

--- a/scripts/services/Link.js
+++ b/scripts/services/Link.js
@@ -1,5 +1,5 @@
 const adaptToSiteUrlRegex = /^https?:\/\/([^/.]+--adaptto-website--adaptto.(hlx|aem).(page|live)|adapt.to|localhost:\d+)(\/.+)$/;
-const adaptToSiteUrlPathnameGroup = 3;
+const adaptToSiteUrlPathnameGroup = 4;
 const downloadUrlRegex = /^.+\.(pdf|zip)$/;
 
 /**

--- a/test/scripts/services/LinkHandler.test.js
+++ b/test/scripts/services/LinkHandler.test.js
@@ -9,6 +9,7 @@ describe('services/LinkHandler', () => {
   it('rewriteUrl', () => {
     expect(rewriteUrl('https://adapt.to/mypath')).to.eq('/mypath');
     expect(rewriteUrl('https://experimental-download-links--adaptto-website--adaptto.hlx.page/2021/schedule')).to.eq('/2021/schedule');
+    expect(rewriteUrl('https://experimental-download-links--adaptto-website--adaptto.aem.page/2021/schedule')).to.eq('/2021/schedule');
     expect(rewriteUrl('https://main--adaptto-website--adaptto.hlx.live/2021/schedule#day1')).to.eq('/2021/schedule#day1');
     expect(rewriteUrl('https://localhost:2000/2021/schedule#day1')).to.eq('/2021/schedule#day1');
     expect(rewriteUrl('https://my.host.com/mypath')).to.eq('https://my.host.com/mypath');


### PR DESCRIPTION
Test URLs:
- Before:
  - https://main--adaptto-website--adaptto.hlx.page/2023/
  - https://main--adaptto-website--adaptto.hlx.live/2023/
  - https://main--adaptto-website--adaptto.aem.page/2023/
  - https://main--adaptto-website--adaptto.aem.live/2023/
- After:
  - https://feature-helix5--adaptto-website--adaptto.hlx.page/2023/
  - https://feature-helix5--adaptto-website--adaptto.hlx.live/2023/
  - https://feature-helix5--adaptto-website--adaptto.aem.page/2023/
  - https://feature-helix5--adaptto-website--adaptto.aem.live/2023/
