### PR TITLE
Support schedule entry type "other_rating"

### DIFF
--- a/scripts/services/ScheduleData.js
+++ b/scripts/services/ScheduleData.js
@@ -6,7 +6,7 @@ import { getQueryIndex } from './QueryIndex.js';
 import ScheduleDay from './ScheduleDay.js';
 import ScheduleEntry from './ScheduleEntry.js';
 
-const validEntryTypes = ['day', 'talk', 'break', 'other'];
+const validEntryTypes = ['day', 'talk', 'break', 'other', 'other_rating'];
 
 /**
  * Calculate scheduling data bases on yearly schedule-data.json and query-index.json.

--- a/test/scripts/services/ScheduleData.test.js
+++ b/test/scripts/services/ScheduleData.test.js
@@ -27,7 +27,7 @@ describe('services/ScheduleData', () => {
     expect(other11.title).to.eq('Opening Words / Status Apache Sling');
     expect(other11.duration).to.eq(30);
     expect(other11.durationFAQ).to.eq(0);
-    expect(other11.type).to.eq('other');
+    expect(other11.type).to.eq('other_rating');
     expect(other11.speakers).to.eql(['Robert Munteanu', 'Stefan Seifert']);
     expect(other11.talkPath).to.undefined;
 

--- a/test/test-data/schedule-data-2020.json
+++ b/test/test-data/schedule-data-2020.json
@@ -19,7 +19,7 @@
       "Entry": "Opening Words / Status Apache Sling",
       "Duration": "30",
       "FAQ": "",
-      "Type": "other",
+      "Type": "other_rating",
       "Speakers": "Robert Munteanu, Stefan Seifert"
     },
     {

--- a/test/test-data/schedule-data-2021.json
+++ b/test/test-data/schedule-data-2021.json
@@ -19,7 +19,7 @@
       "Entry": "Opening Words / Status Apache Sling",
       "Duration": "30",
       "FAQ": "",
-      "Type": "other",
+      "Type": "other_rating",
       "Speakers": "Robert Munteanu, Stefan Seifert"
     },
     {


### PR DESCRIPTION
Test URLs:
- Before: https://main--adaptto-website--adaptto.aem.live/2025/schedule
- After: https://feature-other-rating--adaptto-website--adaptto.aem.live/2025/schedule
