### PR TITLE
Talk Archive: Resolver issue in Speaker filter options with different speakers sharing same name

### DIFF
--- a/scripts/services/TalkArchive.js
+++ b/scripts/services/TalkArchive.js
@@ -1,5 +1,6 @@
 import { removeTitleSuffix } from '../utils/metadata.js';
 import { getYearFromPath } from '../utils/path.js';
+import { getSiteRootPath } from '../utils/site.js';
 import { getQueryIndex } from './QueryIndex.js';
 import TalkArchiveFullTextIndex from './TalkArchiveFullTextIndex.js';
 import TalkArchiveItem from './TalkArchiveItem.js';
@@ -13,6 +14,26 @@ function getDistinctSortedList(items) {
   const distinctItems = [...new Set(items)]
     .filter((item) => item !== undefined);
   return distinctItems.sort();
+}
+
+/**
+ * Resolves the speaker references of a talk to their display names.
+ * Speaker references may be display names or internal speaker document/path names
+ * (used to disambiguate speakers that share the same display name). Each reference
+ * is resolved to the actual speaker display name; unresolved references are kept as-is.
+ * @typedef {import('./QueryIndex').default} QueryIndex
+ * @typedef {import('./QueryIndexItem').default} QueryIndexItem
+ * @param {QueryIndex} queryIndex Query index
+ * @param {QueryIndexItem} talkItem Talk query index item
+ * @returns {string[]} Speaker display names
+ */
+function getSpeakerDisplayNames(queryIndex, talkItem) {
+  const siteRootPath = getSiteRootPath(talkItem.path);
+  return talkItem.getSpeakers()
+    .map((speaker) => {
+      const speakerItem = queryIndex.getSpeaker(speaker, siteRootPath);
+      return speakerItem?.title ?? speaker;
+    });
 }
 
 /**
@@ -55,7 +76,7 @@ export default class TalkArchive {
         talk.description = item.description;
         talk.keywords = item.getKeywords();
         talk.tags = item.getTags();
-        talk.speakers = item.getSpeakers();
+        talk.speakers = getSpeakerDisplayNames(queryIndex, item);
         return talk;
       })
       .filter((talk) => talk.speakers.length > 0);

--- a/test/scripts/services/TalkArchive.samename.test.js
+++ b/test/scripts/services/TalkArchive.samename.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-unused-expressions */
+/* global describe it */
+
+import { expect } from '@esm-bundle/chai';
+import { getTalkArchive } from '../../../scripts/services/TalkArchive.js';
+import TalkArchiveFilter from '../../../scripts/services/TalkArchiveFilter.js';
+import { stubFetchUrlMap } from '../test-utils.js';
+
+stubFetchUrlMap({ '/query-index.json': '/test/test-data/query-index-schedule-samename.json' });
+const talkArchive = await getTalkArchive();
+
+describe('services/TalkArchive same-name speakers', () => {
+  it('resolves speaker document names to display names in filter options', () => {
+    expect(talkArchive.getSpeakerFilterOptions()).to.eql([
+      'Konrad Windszus',
+      'Nitin Gupta',
+    ]);
+  });
+
+  it('resolves speaker document names to display names on talks', () => {
+    talkArchive.applyFilter(undefined);
+    const talks = talkArchive.getFilteredTalks();
+    const talkOne = talks.find((talk) => talk.path === '/2024/schedule/talk-one');
+    const talkTwo = talks.find((talk) => talk.path === '/2024/schedule/talk-two');
+    expect(talkOne.speakers).to.eql(['Nitin Gupta']);
+    expect(talkTwo.speakers).to.eql(['Nitin Gupta']);
+  });
+
+  it('filters both same-name speaker variants by display name', () => {
+    const filter = new TalkArchiveFilter();
+    filter.speakers = ['Nitin Gupta'];
+    talkArchive.applyFilter(filter);
+    const talks = talkArchive.getFilteredTalks();
+    expect(talks.map((talk) => talk.path).sort()).to.eql([
+      '/2024/schedule/talk-one',
+      '/2024/schedule/talk-two',
+    ]);
+  });
+});

--- a/test/test-data/query-index-schedule-samename.json
+++ b/test/test-data/query-index-schedule-samename.json
@@ -1,0 +1,33 @@
+{
+  "data": [
+    {
+      "path": "/2024/"
+    },
+    {
+      "path": "/speakers/nitin-gupta",
+      "title": "Nitin Gupta"
+    },
+    {
+      "path": "/speakers/nitin-gupta-nitigupt",
+      "title": "Nitin Gupta"
+    },
+    {
+      "path": "/2024/schedule/talk-one",
+      "title": "Talk One - adaptTo() 2024",
+      "speakers": "nitin-gupta",
+      "tags": "[\"AEM\"]"
+    },
+    {
+      "path": "/2024/schedule/talk-two",
+      "title": "Talk Two - adaptTo() 2024",
+      "speakers": "nitin-gupta-nitigupt",
+      "tags": "[\"AEM\"]"
+    },
+    {
+      "path": "/2024/schedule/talk-three",
+      "title": "Talk Three - adaptTo() 2024",
+      "speakers": "Konrad Windszus",
+      "tags": "[\"Sling\"]"
+    }
+  ]
+}


### PR DESCRIPTION
Test URLs:
- Before: https://main--adaptto-website--adaptto.aem.live/2026/archive
- After: https://feature-archive-spaker-same-name-fix--adaptto-website--adaptto.aem.live/2026/archive
